### PR TITLE
Remove support for `?` characters and CronError

### DIFF
--- a/cfron-worker/src/lib.rs
+++ b/cfron-worker/src/lib.rs
@@ -69,7 +69,7 @@ pub fn describe(cron: &str) -> DescriptionResult {
 
     match cron.parse::<CronExpr>() {
         Ok(expr) => {
-            let compiled = Cron::new(expr).expect("Parsed valid cron expression");
+            let compiled = Cron::new(expr);
             let est_future_executions = compiled.iter_from(Utc::now()).take(5).collect();
 
             DescriptionResult {


### PR DESCRIPTION
It just complicates everything and makes it hard to validate by parsing. By removing support for `?` we can match up closer with the behavior of normal cron strings which support both day of the month and day of the week both existing and makes the type model (CronExpr) match up perfectly with what we actually support, making a conversion from CronExpr to Cron infallible.