### PR TITLE
Add future time limit iter API

### DIFF
--- a/saffron/examples/future-times.rs
+++ b/saffron/examples/future-times.rs
@@ -18,7 +18,7 @@ fn main() {
                     println!("Failed check! Cron does not contain {}.", time);
                     break;
                 }
-                println!("{}", time);
+                println!("{}", time.format("%F %R"));
             }
         }
         Ok(None) => println!("Usage: cargo run --example future-times -- \"[cron expression]\""),


### PR DESCRIPTION
Closes #14

This also refactors future time matching.

Example:

```rust
use saffron::Cron;
use chrono::prelude::*;

let cron = "*/10 * * * *".parse::<Cron>().expect("Couldn't parse expression!");
let start = Utc.ymd(1970, 1, 1).and_hms(0, 0, 0);

// effectively the same as iter_from
let _ = cron.clone().iter(start..);

// all matching times in the next 30 minutes
let _ = cron.clone().iter(start..(start + chrono::Duration::from_secs(60 * 30)));
```